### PR TITLE
docs: Add the standard curve database (neuromancer.sk/std/).

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -173,6 +173,12 @@
     year         = 2015,
 }
 
+@misc{std-curves,
+    title  = "Standard curve database",
+    author = "Jan Jancar and Vladimir Sedlacek",
+    url    = "https://neuromancer.sk/std/",
+}
+
 @misc{curvechains,
     title   = "The Most Efficient Known Addition Chains for Field Element and Scalar Inversion for the Most Popular and Most Unpopular Elliptic Curves",
     author  = "Brian Smith",

--- a/docs/references.md
+++ b/docs/references.md
@@ -171,6 +171,7 @@
 * [Elligator: Elliptic-curve points indistinguishable from uniform random strings](https://eprint.iacr.org/2013/325) Daniel J. Bernstein and Mike Hamburg and Anna Krasnova and Tanja Lange.
 * [Security dangers of the NIST curves](https://cr.yp.to/talks/2013.09.16/slides-djb-20130916-a4.pdf) Daniel J. Bernstein and Tanja Lange.
 * [Ed448-Goldilocks, a new elliptic curve](https://eprint.iacr.org/2015/625) Mike Hamburg.
+* [Standard curve database](https://neuromancer.sk/std/) Jan Jancar and Vladimir Sedlacek.
 ## Specifications
 * [RFC 7748: Elliptic Curves for Security](https://www.rfc-editor.org/rfc/rfc7748.txt)
 * [SIKE/SIDH Spec](https://sike.org/files/SIDH-spec.pdf)

--- a/docs/references.yml
+++ b/docs/references.yml
@@ -735,6 +735,11 @@ references:
   fields:
     howpublished: Cryptology ePrint Archive, Report 2015/625
     year: "2015"
+- title: Standard curve database
+  url: https://neuromancer.sk/std/
+  author: Jan Jancar and Vladimir Sedlacek
+  section: curves
+  id: std-curves
 - title: The Most Efficient Known Addition Chains for Field Element and Scalar Inversion for the Most Popular and Most Unpopular Elliptic Curves
   url: https://briansmith.org/ecc-inversion-addition-chains-01
   author: Brian Smith


### PR DESCRIPTION
Hi there,
This is a very cool project! This PR adds the Standard curve database at https://neuromancer.sk/std/ to the docs as it is a relavant listing of elliptic curves used for cryptography. You may also want to know of https://github.com/J08nY/pyecsca-codegen which is a package from the pyecsca (Python Elliptic Curve Side-Channel Analysis toolkit) project that focuses on generating C code implementations of elliptic curve cryptography for embedded devices that also uses EFD for the formulas.